### PR TITLE
fix: kill jobs upon cancelling

### DIFF
--- a/snakemake_executor_plugin_cluster_sync/__init__.py
+++ b/snakemake_executor_plugin_cluster_sync/__init__.py
@@ -117,9 +117,8 @@ class Executor(RemoteExecutor):
                 self.report_job_error(active_job)
 
     def cancel_jobs(self, active_jobs: List[SubmittedJobInfo]):
-        # Cancel all active jobs.
-        # This method is called when Snakemake is interrupted.
-        self.logger.info("Will exit after finishing currently running jobs.")
+        for active_job in active_jobs:
+            active_job.aux["process"].kill()
 
     def get_job_exec_prefix(self, job):
         if self.workflow.storage_settings.assume_common_workdir:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job cancellation to immediately terminate all active job processes instead of only logging a message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->